### PR TITLE
Use %zu format specifier for all sizeof prints

### DIFF
--- a/03 - Pointers & Arrays/part2_arrays_multidim.c
+++ b/03 - Pointers & Arrays/part2_arrays_multidim.c
@@ -75,7 +75,7 @@ int main(void)
     };
 
     /* (3) Sizeofs */
-    printf("%ld %ld %ld %ld \n", sizeof(a4), sizeof(a4[0]), sizeof(a4[0][0]), sizeof(a4[0][0][0]));
+    printf("%zu %zu %zu %zu \n", sizeof(a4), sizeof(a4[0]), sizeof(a4[0][0]), sizeof(a4[0][0][0]));
 
 
     return 0;

--- a/03 - Pointers & Arrays/part3_pointers_basic.c
+++ b/03 - Pointers & Arrays/part3_pointers_basic.c
@@ -60,10 +60,10 @@ int main(void)
     int32_t *p3 = NULL;
     int64_t *p4 = NULL;
     
-    printf("sizeof(p1) = %ld || sizeof(*p1) = %ld\n", sizeof(p1), sizeof(*p1));
-    printf("sizeof(p2) = %ld || sizeof(*p2) = %ld\n", sizeof(p2), sizeof(*p2));
-    printf("sizeof(p3) = %ld || sizeof(*p3) = %ld\n", sizeof(p3), sizeof(*p3));
-    printf("sizeof(p4) = %ld || sizeof(*p4) = %ld\n", sizeof(p4), sizeof(*p4));
+    printf("sizeof(p1) = %zu || sizeof(*p1) = %zu\n", sizeof(p1), sizeof(*p1));
+    printf("sizeof(p2) = %zu || sizeof(*p2) = %zu\n", sizeof(p2), sizeof(*p2));
+    printf("sizeof(p3) = %zu || sizeof(*p3) = %zu\n", sizeof(p3), sizeof(*p3));
+    printf("sizeof(p4) = %zu || sizeof(*p4) = %zu\n", sizeof(p4), sizeof(*p4));
 
 
     /* 

--- a/07 - Strings And Mallocs/part1_strings_basic.c
+++ b/07 - Strings And Mallocs/part1_strings_basic.c
@@ -29,14 +29,14 @@ int main(void)
 
     /* Data Section (r/o) */
     char *question = "Hodor?";
-    printf("Size of question: %ld\n", sizeof(question));
+    printf("Size of question: %zu\n", sizeof(question));
 
     /* Illegal: */
     /* question[5] = "!"; */
 
     /* Global Variables */
-    printf("Size of g_question1: %ld\n", sizeof(g_question1));
-    printf("Size of g_question2: %ld\n", sizeof(g_question2));
+    printf("Size of g_question1: %zu\n", sizeof(g_question1));
+    printf("Size of g_question2: %zu\n", sizeof(g_question2));
     
     g_question1[5] = '!';
     printf("Hodor? %s\n", g_question1);

--- a/07 - Strings And Mallocs/part5_allocating_arrays.c
+++ b/07 - Strings And Mallocs/part5_allocating_arrays.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
     // int *twodim = (int *) malloc(sizeof(int[3][4]));
 
     /* You can see sizes are equal */
-    printf("Sizeof: %ld == %ld\n", sizeof(int[3][4]), 3 * 4 * sizeof(int) );
+    printf("Sizeof: %zu == %zu\n", sizeof(int[3][4]), 3 * 4 * sizeof(int) );
 
     /* usage examples (first and second alrenatives) */
     // int i = 0;

--- a/08 - Advanced Data Types/part2.c
+++ b/08 - Advanced Data Types/part2.c
@@ -47,8 +47,8 @@ int main(void)
     point_t p1 = {0};
     complex_t c1 = {0};
 
-    printf("Size of p1: %ld\n", sizeof(p1));
-    printf("Size of c1: %ld\n", sizeof(c1));
+    printf("Size of p1: %zu\n", sizeof(p1));
+    printf("Size of c1: %zu\n", sizeof(c1));
 
     p1.x = 100;
     p1.y = 200;

--- a/08 - Advanced Data Types/part5.c
+++ b/08 - Advanced Data Types/part5.c
@@ -64,15 +64,15 @@ int main(void)
     free(line);
 
     /* (2) Packed Structures */
-    printf("Size of ex1: %ld\n", sizeof(struct ex1));
-    printf("Size of ex2: %ld\n", sizeof(struct ex2));
-    printf("Size of pex1: %ld\n", sizeof(struct pex1));
-    printf("Size of pex2: %ld\n", sizeof(struct pex2));
+    printf("Size of ex1: %zu\n", sizeof(struct ex1));
+    printf("Size of ex2: %zu\n", sizeof(struct ex2));
+    printf("Size of pex1: %zu\n", sizeof(struct pex1));
+    printf("Size of pex2: %zu\n", sizeof(struct pex2));
 
     struct ex1 boo[2];
     struct pex1 yaa[2];
-    printf("Size of boo: %ld\n", sizeof(boo));
-    printf("Size of yaa: %ld\n", sizeof(yaa));
+    printf("Size of boo: %zu\n", sizeof(boo));
+    printf("Size of yaa: %zu\n", sizeof(yaa));
 
 
 


### PR DESCRIPTION
sizeof yields a size_t, whose correct printf conversion is %zu. Replace
the %ld specifiers used in sizeof printouts across the lessons to avoid
undefined behavior / compiler warnings.