### PR TITLE
Fix typos and grammar in documentation and comments

### DIFF
--- a/01 - Intro/instructor_notes.md
+++ b/01 - Intro/instructor_notes.md
@@ -10,7 +10,7 @@
 - => Recent years transition back to compiled languages (go, swift, rust)
 - => Android vs iPhone development and simulator (difference between swift to java)
 - => Apple's architecture migration (+Rosetta)
-- **Disclaimer:** Starting from the bottom to make sure eveyone understand
+- **Disclaimer:** Starting from the bottom to make sure everyone understands
 
 ## Part 1 - Intro
 
@@ -44,4 +44,4 @@
 * Linux Kernel + Windows in C
 * Since 1972 and kicking! (In top 3 most common for long time)
 * Writing C will help you understand how computers work
-* as a user you dont need to install packages to support it will work on any computer! (From the strongest to the shittiest)
+* as a user you don't need to install packages to support it will work on any computer! (From the strongest to the shittiest)

--- a/05 - Linking & Compiling/LINUX.md
+++ b/05 - Linking & Compiling/LINUX.md
@@ -4,7 +4,7 @@ Show Preprocessor output using:
 `gcc -E file.c`
 
 1. Use #define (no #include) to show how it works in search replace
-2. Use #ifdef ifndef to show that files are not alawys duplicate:
+2. Use #ifdef ifndef to show that files are not always duplicate:
 
 ```c
 #ifndef BLA
@@ -63,7 +63,7 @@ RETURN
 PUSH 10
 PUSH 20
 CALL SUM
-EAX contians the result
+EAX contains the result
 ```
 int32_t exp(int32_t base, int32_t value, int32_t)
 

--- a/05 - Linking & Compiling/WINDOWS.md
+++ b/05 - Linking & Compiling/WINDOWS.md
@@ -1,4 +1,4 @@
-# .lib is a collection of .obj files and should have be treated equally
+# .lib is a collection of .obj files and should be treated equally
 
 .text: Code 
 .data: Initialized data
@@ -80,7 +80,7 @@ dumpbin /IMPORTS one.dll
 
 # DUMPBIN
 dumpbin /SYMBOLS main.obj
-> We can see UDNEF on hello()
+> We can see UNDEF on hello()
 dumpbin /ALL main.obj /OUT:main.dumpbin.txt
 dumpbin /ALL one.lib /OUT:one.dumpbin.txt
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# C Progamming Language Training Drafts
+# C Programming Language Training Drafts
 
 Drafts for examples shown in class during C Programming Course
 


### PR DESCRIPTION
## Summary
This PR corrects multiple spelling and grammar errors across the training material documentation and code comments.

## Changes Made
- Fixed typo "eveyone" → "everyone" in intro disclaimer
- Fixed typo "dont" → "don't" (contraction) in C language notes
- Fixed typo "alawys" → "always" in linking & compiling notes
- Fixed typo "contians" → "contains" in assembly code comments
- Fixed grammar "should have be" → "should be" in Windows documentation
- Fixed typo "UDNEF" → "UNDEF" in DUMPBIN output notes
- Fixed typo "Progamming" → "Programming" in README title

## Details
These are documentation and comment-only changes that improve clarity and correctness of the training materials without affecting any functional code.

https://claude.ai/code/session_01PChSEMuUrdFGDRqja8zRZ9